### PR TITLE
allow amounts over 1000 by providing large amount in the format the moneris API expects

### DIFF
--- a/includes/class-give-moneris-gateway.php
+++ b/includes/class-give-moneris-gateway.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Give_Moneris_Gateway {
-	
+
 	/**
 	 * Default Gateway ID.
 	 *
@@ -29,7 +29,7 @@ class Give_Moneris_Gateway {
 	 * @var string
 	 */
 	public $id = '';
-	
+
 	/**
 	 * Access Token
 	 *
@@ -39,7 +39,7 @@ class Give_Moneris_Gateway {
 	 * @var string
 	 */
 	public $access_token = '';
-	
+
 	/**
 	 * Store ID
 	 *
@@ -49,39 +49,39 @@ class Give_Moneris_Gateway {
 	 * @var string
 	 */
 	public $store_id = '';
-	
+
 	/**
 	 * Give_Moneris_Gateway constructor.
 	 *
+	 * @return void
 	 * @since  1.0.0
 	 * @access public
 	 *
-	 * @return void
 	 */
 	public function __construct() {
-		
+
 		$this->id           = 'moneris';
 		$this->access_token = give_get_option( 'give_moneris_access_token' );
 		$this->store_id     = give_get_option( 'give_moneris_store_id' );
-		
+
 		// Bailout, if gateway is not active.
 		if ( ! give_is_gateway_active( $this->id ) ) {
 			return;
 		}
-		
+
 		add_action( "give_{$this->id}_cc_form", array( $this, 'display_billing_details' ), 10, 1 );
 		add_action( "give_gateway_{$this->id}", array( $this, 'process_donation' ) );
 	}
-	
+
 	/**
 	 * This function will be used to do all the heavy lifting for processing a donation payment.
-	 *
-	 * @since  1.0.0
-	 * @access public
 	 *
 	 * @param array $donation_data List of donation data.
 	 *
 	 * @return void
+	 * @since  1.0.0
+	 * @access public
+	 *
 	 */
 	public function process_donation( $donation_data ) {
 
@@ -89,18 +89,18 @@ class Give_Moneris_Gateway {
 		if ( $this->id !== $donation_data['gateway'] ) {
 			return;
 		}
-		
+
 		// Validate gateway nonce.
 		give_validate_nonce( $donation_data['gateway_nonce'], 'give-gateway' );
-		
+
 		// Make sure we don't have any left over errors present.
 		give_clear_errors();
-		
+
 		// Validate fields here.
-		
+
 		// Any errors?
 		$errors = give_get_errors();
-		
+
 		// No errors, proceed.
 		if ( ! $errors ) {
 
@@ -118,72 +118,72 @@ class Give_Moneris_Gateway {
 				'user_info'       => $donation_data['user_info'],
 				'status'          => 'pending'
 			);
-			
+
 			// Create a pending donation.
 			$donation_id = give_insert_payment( $args );
 			
 			$exp_month   = sprintf( '%02d', $donation_data['card_info']['card_exp_month'] );
 			$exp_year    = substr( $donation_data['card_info']['card_exp_year'], 2, 2 );
 			$expiry_date = "{$exp_year}{$exp_month}";
-			
+
 			$payment_object = array(
 				'type'               => 'purchase',
 				'order_id'           => give_moneris_get_unique_donation_id( $donation_id ),
 				'cust_id'            => give_get_payment_donor_id( $donation_id ),
-				'amount'             => $donation_amount,
+				'amount'             => give_format_decimal( array( 'amount' => $donation_data['price'] ) ),
 				'pan'                => $donation_data['card_info']['card_number'],
 				'expdate'            => $expiry_date,
 				'crypt_type'         => 7, // @todo provide a filter to change the crypt type.
 				'dynamic_descriptor' => give_moneris_get_statement_descriptor(),
 			);
-			
+
 			$transaction_object = new Give_Moneris\mpgTransaction( $payment_object );
 			$request_object     = new Give_Moneris\mpgRequest( $transaction_object );
 			$request_object->setProcCountryCode( give_get_option( 'base_country' ) );
 			$request_object->setTestMode( give_is_test_mode() );
-			
-			$https_post_object  = new Give_Moneris\mpgHttpsPost( $this->store_id, $this->access_token, $request_object );
-			$response           = $https_post_object->getMpgResponse();
+
+			$https_post_object = new Give_Moneris\mpgHttpsPost( $this->store_id, $this->access_token, $request_object );
+			$response          = $https_post_object->getMpgResponse();
 
 			// Prepare Response Variables.
 			$response_code       = (int) $response->getResponseCode();
 			$is_payment_complete = (bool) $response->getComplete();
-			
+
 			if ( $is_payment_complete & $response_code !== null ) {
-				
+
 				switch ( $response_code ) {
-					
+
 					case $response_code <= 29:
-						
+
 						// Save Transaction ID to Donation.
 						$transaction_id = $response->getTxnNumber();
 						give_set_payment_transaction_id( $donation_id, $transaction_id );
 						give_insert_payment_note( $donation_id, "Transaction ID: {$transaction_id}" );
 						give_insert_payment_note( $donation_id, "Approval Code: {$response->getAuthCode()}" );
-						
+
 						if ( ! empty( $transaction_id ) ) {
-							
+
 							// Set status to completed.
 							give_update_payment_status( $donation_id );
-							
+
 							// All done. Send to success page.
 							give_send_to_success_page();
 						}
-						
+
 						break;
-					
+
 					case $response_code >= 50 && $response_code <= 99:
-						
+
 						// Something went wrong outside of Moneris.
 						give_record_gateway_error(
 							__( 'Moneris Error', 'give-moneris' ),
 							sprintf(
-								/* translators: %s Exception error message. */
+							/* translators: %s Exception error message. */
 								__( 'The Moneris Gateway declined the donation with an error. Details: %s', 'give-moneris' ),
 								$response->getMessage()
 							)
 						);
-						
+
 						// Set Error to notify donor.
 						give_set_error( 'give_moneris_gateway_error', __( 'Payment Declined. Please try again.', 'give-moneris' ) );
 
@@ -215,21 +215,21 @@ class Give_Moneris_Gateway {
 						// Send user back to checkout.
 						give_send_back_to_checkout( '?payment-mode=moneris' );
 						break;
-						
+
 				}
-				
+
 			} else {
-				
+
 				// Something went wrong outside of Moneris.
 				give_record_gateway_error(
 					__( 'Moneris Error', 'give-moneris' ),
 					sprintf(
-						/* translators: %s Exception error message. */
+					/* translators: %s Exception error message. */
 						__( 'The Moneris Gateway returned an error while processing a donation. Details: %s', 'give-moneris' ),
 						$response->getMessage()
 					)
 				);
-				
+
 				// Set Error to notify donor.
 				give_set_error( 'give_moneris_gateway_error', __( 'Incomplete Payment Recorded. Please try again.', 'give-moneris' ) );
 
@@ -240,30 +240,30 @@ class Give_Moneris_Gateway {
 				give_send_back_to_checkout( '?payment-mode=moneris' );
 			}
 		}
-		
+
 	}
-	
+
 	/**
 	 * This function is used to display billing details only when enabled.
-	 *
-	 * @since 1.0.0
 	 *
 	 * @param $form_id
 	 *
 	 * @return void
+	 * @since 1.0.0
+	 *
 	 */
 	public function display_billing_details( $form_id ) {
-		
+
 		// Remove Address Fields if user has option enabled.
 		if ( ! give_get_option( 'give_moneris_collect_billing_details' ) ) {
 			remove_action( 'give_after_cc_fields', 'give_default_cc_address_fields' );
 		}
-		
+
 		// Ensure CC field is in place properly.
 		do_action( 'give_cc_form', $form_id );
-		
+
 	}
-	
+
 }
 
 new Give_Moneris_Gateway();


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Fixes #17 

Moneris expects amounts over $1,000.00 to not have a thousands separator.

Previously we weren't passing the amount properly which would result in failed payments.

I've tested that amounts are now formatted properly:

`12345.99`
`1000.00`

API: https://developer.moneris.com/en/Documentation/NA/E-Commerce%20Solutions/API/Purchase

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Amounts with decimals
- Amounts without decimals
- Large amounts
- Small amounts


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.